### PR TITLE
feat: Add initial domain logic tests and update testing guidelines

### DIFF
--- a/.cursor/rules/development-guidelines.mdc
+++ b/.cursor/rules/development-guidelines.mdc
@@ -15,6 +15,8 @@ alwaysApply: true
 
 - Implement appropriate tests for each package
 - Test files should follow the `*_test.go` naming convention
+- Tests should primarily focus on core domain logic.
+- E2E (End-to-End) or extensive communication-related tests (e.g., testing direct external API interactions) are generally not required for routine package development. These may be covered by separate, broader integration tests.
 
 ## Steps to be executed
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/metoro-io/mcp-golang v0.11.0
 	github.com/sirupsen/logrus v1.7.0
 	github.com/yitsushi/go-misskey v1.1.6
+	github.com/golang/mock/gomock v1.6.0
 )
 
 require (

--- a/internal/misskey_tools/note/post_note_test.go
+++ b/internal/misskey_tools/note/post_note_test.go
@@ -1,0 +1,172 @@
+package note
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/ganyariya/misskey-mcp-server/internal/mocks"
+	mcp_golang "github.com/metoro-io/mcp-golang"
+	// "github.com/yitsushi/go-misskey/core" // Keep for core.NewString if used, but not directly in this corrected test logic for Create call args
+	"github.com/yitsushi/go-misskey/models"
+	"github.com/yitsushi/go-misskey/services/notes"
+)
+
+func TestNewPostNoteTool(t *testing.T) {
+	tool := NewPostNoteTool()
+	if tool.Name != toolName {
+		t.Errorf("expected tool name %s, got %s", toolName, tool.Name)
+	}
+	if tool.Description != description {
+		t.Errorf("expected tool description %s, got %s", description, tool.Description)
+	}
+}
+
+func TestPostNoteTool_Register(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockMCPServer := mocks.NewMockServer(ctrl)
+	mockMisskeyClient := mocks.NewMockClient(ctrl)
+	mockNotesService := mocks.NewMockClientInterface(ctrl)
+
+	tool := NewPostNoteTool()
+
+	expectedNoteText := "Test note from MCP"
+	expectedAPIResponseNoteID := "testNoteId123"
+
+	var registeredFunc func(arguments postNoteArguments) (*mcp_golang.ToolResponse, error)
+
+	// Expect RegisterTool to be called on the MCP Server and capture the function
+	mockMCPServer.EXPECT().
+		RegisterTool(
+			tool.GetName(),
+			tool.GetDescription(),
+			gomock.Any(),
+		).
+		DoAndReturn(func(name, desc string, f interface{}) error {
+			// Type assertion for the function
+			cb, ok := f.(func(arguments postNoteArguments) (*mcp_golang.ToolResponse, error))
+			if !ok {
+				t.Fatalf("RegisterTool was called with an unexpected function signature.")
+			}
+			registeredFunc = cb
+			return nil
+		}).
+		Return(nil). // Ensure this is present if the mocked function is expected to return a value.
+		Times(1)
+
+	// Setup expectations for the Misskey client for when the registeredFunc is called
+	// This setup needs to be here because registeredFunc will call these.
+	mockMisskeyClient.EXPECT().Notes().Return(mockNotesService).Times(1)
+	mockNotesService.EXPECT().
+		Create(gomock.Any()).
+		DoAndReturn(func(req notes.CreateRequest) (*notes.CreateResponse, error) {
+			if req.Text == nil || *req.Text != expectedNoteText {
+				t.Errorf("expected text '%s', got '%s'", expectedNoteText, *req.Text)
+			}
+			if req.Visibility != models.VisibilityPublic {
+				t.Errorf("expected visibility '%s', got '%s'", models.VisibilityPublic, req.Visibility)
+			}
+			return &notes.CreateResponse{
+				CreatedNote: models.Note{ID: models.ID(expectedAPIResponseNoteID)},
+			}, nil
+		}).Times(1)
+
+	// Call Register to capture the function
+	err := tool.Register(mockMCPServer, mockMisskeyClient)
+	if err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	// Ensure the function was captured
+	if registeredFunc == nil {
+		t.Fatal("Registered function was not captured by the mock")
+	}
+
+	// Now, call the captured function
+	args := postNoteArguments{Text: expectedNoteText}
+	response, err := registeredFunc(args)
+
+	if err != nil {
+		t.Fatalf("Registered function execution error = %v", err)
+	}
+	if response == nil {
+		t.Fatal("Registered function response was nil")
+	}
+
+	expectedToolResponseContent := "Note posted successfully: " + expectedNoteText + expectedAPIResponseNoteID
+	if len(response.Content) != 1 || response.Content[0].Text == nil || *response.Content[0].Text != expectedToolResponseContent {
+		t.Errorf("Expected tool response content '%s', got '%v'", expectedToolResponseContent, response.Content)
+	}
+}
+
+func TestPostNoteTool_Register_MisskeyError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockMCPServer := mocks.NewMockServer(ctrl)
+	mockMisskeyClient := mocks.NewMockClient(ctrl)
+	mockNotesService := mocks.NewMockClientInterface(ctrl)
+
+	tool := NewPostNoteTool()
+	expectedError := errors.New("misskey API error")
+
+	var registeredFunc func(arguments postNoteArguments) (*mcp_golang.ToolResponse, error)
+
+	mockMCPServer.EXPECT().
+		RegisterTool(tool.GetName(), tool.GetDescription(), gomock.Any()).
+		DoAndReturn(func(name, desc string, f interface{}) error {
+			cb, ok := f.(func(arguments postNoteArguments) (*mcp_golang.ToolResponse, error))
+			if !ok {
+				t.Fatalf("RegisterTool was called with an unexpected function signature.")
+			}
+			registeredFunc = cb
+			return nil
+		}).
+		Return(nil).
+		Times(1)
+
+	// Setup expectations for the Misskey client for when the registeredFunc is called
+	mockMisskeyClient.EXPECT().Notes().Return(mockNotesService).Times(1)
+	mockNotesService.EXPECT().
+		Create(gomock.Any()).
+		Return(nil, expectedError). // Simulate an error from Misskey
+		Times(1)
+
+	err := tool.Register(mockMCPServer, mockMisskeyClient)
+	if err != nil {
+		t.Fatalf("Register() error during setup = %v", err)
+	}
+
+	if registeredFunc == nil {
+		t.Fatal("Registered function was not captured")
+	}
+
+	args := postNoteArguments{Text: "test"}
+	response, err := registeredFunc(args)
+
+	if err == nil {
+		t.Errorf("Expected an error from registered function, but got nil")
+	}
+	if err.Error() != expectedError.Error() { // Compare error messages as errors.Is/As might be more involved with mock errors
+		t.Errorf("Expected error message '%s', got '%s'", expectedError.Error(), err.Error())
+	}
+	if response != nil {
+		t.Errorf("Expected nil response on error, got %v", response)
+	}
+}
+
+func TestPostNoteTool_GetName(t *testing.T) {
+	tool := NewPostNoteTool()
+	if name := tool.GetName(); name != toolName {
+		t.Errorf("GetName() = %s; want %s", name, toolName)
+	}
+}
+
+func TestPostNoteTool_GetDescription(t *testing.T) {
+	tool := NewPostNoteTool()
+	if desc := tool.GetDescription(); desc != description {
+		t.Errorf("GetDescription() = %s; want %s", desc, description)
+	}
+}

--- a/internal/mocks/mock_mcp_server.go
+++ b/internal/mocks/mock_mcp_server.go
@@ -1,0 +1,15 @@
+// This is a placeholder file.
+// Please run mockgen to generate the actual mock code.
+// Example command (adjust -source path as needed):
+// mockgen -source=<path_to_mcp-golang/server.go> -destination=internal/mocks/mock_mcp_server.go -package=mocks Server
+
+package mocks
+
+// Interface Server is defined in github.com/metoro-io/mcp-golang/server.go
+// This is just a placeholder.
+type Server interface {
+	// Add placeholder methods if known, otherwise leave empty.
+	// For example:
+	// SendMessage(topic string, data []byte) error
+	// ReceiveMessage(topic string) ([]byte, error)
+}

--- a/internal/mocks/mock_misskey_client.go
+++ b/internal/mocks/mock_misskey_client.go
@@ -1,0 +1,16 @@
+// This is a placeholder file for the misskey.Client mock.
+// Please run mockgen to generate the actual mock code.
+//
+// Example command (adjust -source path if go-misskey is not vendored or is elsewhere):
+// mockgen -source=../../vendor/github.com/yitsushi/go-misskey/client.go -destination=internal/mocks/mock_misskey_client.go -package=mocks Client
+//
+// If go-misskey is in your Go module cache, the -source path might look like:
+// $GOPATH/pkg/mod/github.com/yitsushi/go-misskey@vX.Y.Z/client.go (replace vX.Y.Z with actual version)
+
+package mocks
+
+// Interface Client is defined in github.com/yitsushi/go-misskey/client.go
+// This is just a placeholder.
+type Client interface {
+	// Add placeholder methods if known, otherwise leave empty.
+}

--- a/internal/mocks/mock_misskey_notes_client.go
+++ b/internal/mocks/mock_misskey_notes_client.go
@@ -1,0 +1,16 @@
+// This is a placeholder file for the notes.ClientInterface mock.
+// Please run mockgen to generate the actual mock code.
+//
+// Example command (adjust -source path if go-misskey is not vendored or is elsewhere):
+// mockgen -source=../../vendor/github.com/yitsushi/go-misskey/services/notes/client.go -destination=internal/mocks/mock_misskey_notes_client.go -package=mocks ClientInterface
+//
+// If go-misskey is in your Go module cache, the -source path might look like:
+// $GOPATH/pkg/mod/github.com/yitsushi/go-misskey@vX.Y.Z/services/notes/client.go (replace vX.Y.Z with actual version)
+
+package mocks
+
+// Interface ClientInterface is defined in github.com/yitsushi/go-misskey/services/notes/client.go
+// This is just a placeholder.
+type ClientInterface interface {
+	// Add placeholder methods if known, otherwise leave empty.
+}


### PR DESCRIPTION
I've added placeholder tests for the `postNoteTool` in the `internal/misskey_tools/note` package. These tests utilize `golang/mock` for mocking dependencies.

The testing guidelines in `.cursor/rules/development-guidelines.mdc` have been updated to emphasize that tests should primarily focus on core domain logic, and that E2E or extensive communication-related tests are not typically required for package development.

**Important Manual Steps Required:**

1.  **Update Go Sum:** You'll need to run `go mod tidy` in the project root to update the `go.sum` file with the new `github.com/golang/mock/gomock` dependency.
2.  **Generate Mocks:** The following `mockgen` commands need to be run manually from the project root to generate the required mock files in `internal/mocks/`. Please adjust the source paths if your Go module cache is not standard:

    ```bash # For mcp_golang.Server (replace with actual path to mcp-golang's server.go) # Example: mockgen -source=$GOPATH/pkg/mod/github.com/metoro-io/mcp-golang@vX.Y.Z/server.go -destination=internal/mocks/mock_mcp_server.go -package=mocks Server echo "Please find github.com/metoro-io/mcp-golang server.go and run: mockgen -source=<path_to_server.go> -destination=internal/mocks/mock_mcp_server.go -package=mocks Server"

    # For misskey.Client (replace with actual path to go-misskey's client.go) # Example: mockgen -source=$GOPATH/pkg/mod/github.com/yitsushi/go-misskey@vX.Y.Z/client.go -destination=internal/mocks/mock_misskey_client.go -package=mocks Client echo "Please find github.com/yitsushi/go-misskey client.go and run: mockgen -source=<path_to_client.go> -destination=internal/mocks/mock_misskey_client.go -package=mocks Client"

    # For notes.ClientInterface (replace with actual path to go-misskey's services/notes/client.go) # Example: mockgen -source=$GOPATH/pkg/mod/github.com/yitsushi/go-misskey@vX.Y.Z/services/notes/client.go -destination=internal/mocks/mock_misskey_notes_client.go -package=mocks ClientInterface echo "Please find github.com/yitsushi/go-misskey services/notes/client.go and run: mockgen -source=<path_to_notes_client.go> -destination=internal/mocks/mock_misskey_notes_client.go -package=mocks ClientInterface" ```

After these steps, `go test ./...` should pass (assuming the domain logic in `post_note.go` is correct).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated testing guidelines to clarify focus on core domain logic and recommend handling extensive integration or E2E tests separately.

- **Chores**
  - Added a new dependency for mocking in tests.
  - Introduced placeholder files for mock interfaces to support future test development.

- **Tests**
  - Added comprehensive unit tests for note posting functionality, including success and error handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->