### PR TITLE
Update testing guidelines and add initial test for post_note tool

### DIFF
--- a/.cursor/rules/development-guidelines.mdc
+++ b/.cursor/rules/development-guidelines.mdc
@@ -13,7 +13,8 @@ alwaysApply: true
 
 ## Testing
 
-- Implement appropriate tests for each package
+- Implement appropriate tests for each package, focusing on core domain logic.
+- Tests for direct external API interactions or comprehensive E2E (End-to-End) scenarios are not required at this stage, to maintain a focus on easily testable units.
 - Test files should follow the `*_test.go` naming convention
 
 ## Steps to be executed

--- a/internal/misskey_tools/note/post_note_test.go
+++ b/internal/misskey_tools/note/post_note_test.go
@@ -1,0 +1,19 @@
+package note
+
+import (
+	"testing"
+)
+
+func TestNewPostNoteTool(t *testing.T) {
+	tool := NewPostNoteTool()
+
+	expectedName := "post_misskey_note"
+	if tool.GetName() != expectedName {
+		t.Errorf("Expected tool name to be '%s', but got '%s'", expectedName, tool.GetName())
+	}
+
+	expectedDescription := "Post a note to Misskey"
+	if tool.GetDescription() != expectedDescription {
+		t.Errorf("Expected tool description to be '%s', but got '%s'", expectedDescription, tool.GetDescription())
+	}
+}


### PR DESCRIPTION
This commit introduces two main changes:

1.  Updated `.cursor/rules/development-guidelines.mdc` to clarify the testing policy. The policy now emphasizes that tests should focus on core domain logic, and that E2E or communication-related tests are not the primary focus at this stage.

2.  Added a simple unit test for the `post_note` tool in `internal/misskey_tools/note/post_note_test.go`. This test verifies that the `NewPostNoteTool` function correctly initializes the `Name` and `Description` properties of the tool.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded testing guidelines to clarify focus on core domain logic and limit scope to easily testable units, excluding external API and full end-to-end scenarios.

- **Tests**
  - Added a new test to verify correct naming and description of the Misskey note posting tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->